### PR TITLE
chore: require installation of 'eslint' v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "test": "jest --clearCache && jest",
     "pack": "npm pack ./dist"
   },
+  "peerDependencies": {
+    "eslint": ">= 7"
+  },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "^4.1.1"
   },


### PR DESCRIPTION
Since 'eslint' is a prerequisite for 'eslint-plugin-ui-testing', it is necessary to require its installation.